### PR TITLE
Add accessor bundle

### DIFF
--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -43,7 +43,8 @@ namespace cmoh {
  *
  * TODO: further explanation
  *
- * TODO: mention of factory
+ * Users are discouraged from constructing accessor bundles directly. Usexi
+ * `bundle()` instread as a factory.
  */
 template <
     typename ...Accessors
@@ -95,6 +96,22 @@ public:
 
     // TODO: access methods
 };
+
+
+/**
+ * Construct an accessor bundle from a bunch of accessors
+ *
+ * \returns an accessor bundle holding all the accessors supplied
+ */
+template <
+    typename ...Accessors
+>
+accessor_bundle<Accessors...>
+bundle(
+    Accessors... accessors ///< accessors to bundle
+) {
+    return accessor_bundle<Accessors...>(accessors...);
+}
 
 
 }

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -84,7 +84,34 @@ public:
     accessor_bundle(accessor_bundle&&) = default;
     accessor_bundle() = delete;
 
-    // TODO: access methods
+    /**
+     * Get the value of a specific attribute from an object
+     *
+     * \returns the value of the attribute
+     */
+    template <typename Attribute>
+    typename std::enable_if<
+        !std::is_same<Attribute, typename accessor::attr>::value,
+        typename Attribute::type
+    >::type
+    get(
+        object_type const& obj ///< object from which to get the value
+    ) const {
+        return _next.get<Attribute>(obj);
+    }
+
+    template <typename Attribute>
+    typename std::enable_if<
+        std::is_same<Attribute, typename accessor::attr>::value,
+        typename Attribute::type
+    >::type
+    get(
+        object_type const& obj ///< object from which to get the value
+    ) const {
+        return _accessor.get(obj);
+    }
+
+    // TODO: setters
 };
 
 
@@ -94,7 +121,19 @@ class accessor_bundle<> {
 public:
     typedef void object_type;
 
-    // TODO: access methods
+    // accept whatever comes in and error out
+    template <typename Attribute, typename ObjectType>
+    typename Attribute::type
+    get(
+        ObjectType const& obj
+    ) const {
+        static_assert(
+            true,
+            "The attribute can not be accessed via this bundle."
+        );
+    }
+
+    // TODO: setters
 };
 
 

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_ACCESSOR_BUNDLE_HPP__
+#define CMOH_ACCESSOR_BUNDLE_HPP__
+
+
+// std includes
+#include <type_traits>
+
+// local includes
+#include <cmoh/utils.hpp>
+
+
+namespace cmoh {
+
+
+/**
+ * Accessor bundle
+ *
+ * Instantiations of this template bundle accessors and make them conveniently
+ * accessible as a group, posing as an abstraction layer.
+ *
+ * TODO: further explanation
+ *
+ * TODO: mention of factory
+ */
+template <
+    typename ...Accessors
+>
+class accessor_bundle;
+
+
+// Main specialization
+template <
+    typename Accessor,
+    typename ...Accessors
+>
+class accessor_bundle<Accessor, Accessors...> {
+    typedef Accessor accessor;
+    accessor _accessor;
+
+    typedef accessor_bundle<Accessors...> next;
+    next _next;
+
+public:
+    /**
+     * The C++ type which may be accessed using the accessor bundle
+     */
+    typedef typename std::conditional<
+        count<Accessors...>::value == 0,
+        typename accessor::object_type,
+        typename next::object_type
+    >::type object_type;
+    static_assert(
+        std::is_same<typename accessor::object_type, object_type>::value,
+        "All accessors in a bundle must have the same object type"
+    );
+
+    accessor_bundle(accessor accessor, Accessors... accessors) :
+            _accessor(accessor), _next(accessors...) {};
+    accessor_bundle(accessor_bundle const&) = default;
+    accessor_bundle(accessor_bundle&&) = default;
+    accessor_bundle() = delete;
+
+    // TODO: access methods
+};
+
+
+// Recursion terminator
+template <>
+class accessor_bundle<> {
+public:
+    typedef void object_type;
+
+    // TODO: access methods
+};
+
+
+}
+
+
+#endif

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -27,6 +27,7 @@
 
 // std includes
 #include <type_traits>
+#include <utility>
 
 // local includes
 #include <cmoh/utils.hpp>
@@ -111,7 +112,30 @@ public:
         return _accessor.get(obj);
     }
 
-    // TODO: setters
+    /**
+     * Set the value of a specific attribute on an object
+     */
+    template <typename Attribute>
+    typename std::enable_if<
+        !std::is_same<Attribute, typename accessor::attr>::value
+    >::type
+    set(
+        object_type& obj, ///< object on which to set the attribute
+        typename Attribute::type&& value ///< value to set
+    ) const {
+        _next.set<Attribute>(obj, std::forward<typename Attribute::type>(value));
+    }
+
+    template <typename Attribute>
+    typename std::enable_if<
+        std::is_same<Attribute, typename accessor::attr>::value
+    >::type
+    set(
+        object_type& obj, ///< object on which to set the attribute
+        typename Attribute::type&& value ///< value to set
+    ) const {
+        _accessor.set(obj, std::forward<typename Attribute::type>(value));
+    }
 };
 
 
@@ -133,7 +157,18 @@ public:
         );
     }
 
-    // TODO: setters
+    // accept whatever comes in and error out
+    template <typename ObjectType, typename Value>
+    void
+    get(
+        ObjectType const& obj,
+        Value&& value
+    ) const {
+        static_assert(
+            true,
+            "The attribute can not be accessed via this bundle."
+        );
+    }
 };
 
 

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -112,7 +112,7 @@ struct attribute {
                 type&& value ///< value to set
             ) const {
                 static_assert(Setter != nullptr, "No setter defined for this attribute");
-                (obj.*Setter)(std::forward(value));
+                (obj.*Setter)(std::forward<type>(value));
             }
         };
     };

--- a/include/cmoh/utils.hpp
+++ b/include/cmoh/utils.hpp
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_UTILS_HPP__
+#define CMOH_UTILS_HPP__
+
+
+namespace cmoh {
+
+
+/**
+ * Count the number of arguments in a template parameter pack
+ *
+ * Instantiations of this struct will contain a static member `value`, which
+ * will hold the number of arguments supplied to the template.
+ */
+template <
+    typename ...Args
+>
+struct count;
+
+// Specialization for lists of at least one argument
+template <
+    typename Arg0,
+    typename ...Args
+>
+struct count<Arg0, Args...> {
+    static constexpr unsigned long int value = count<Args...>::value + 1;
+};
+
+// Recursion terminator/specialization for zero arguments
+template <>
+struct count<> {
+    static constexpr unsigned long int value = 0;
+};
+
+
+}
+
+
+#endif


### PR DESCRIPTION
This PR introduces the accessor bundle, which will be the core abstraction layer around which CMOH is build. The initial version only has methods for getting and setting attributes' values via the accessors.

The PR also contains some minor fix for `cmoh::atrribute` and the introduction of a utility header.
