### PR TITLE
Mod attribute method accessor

### DIFF
--- a/examples/attributes_example.cpp
+++ b/examples/attributes_example.cpp
@@ -44,8 +44,8 @@ int main(int argc, char* argv[]) {
     // From the attributes we pull accessors for a concrete C++ type and bundle
     // them in an accessor bundle.
     auto accessors = bundle(
-        name::binding<person>::methods<&person::name, &person::set_name>(),
-        age::binding<person>::methods<&person::age>()
+        name::accessor<person>(&person::name, &person::set_name),
+        age::accessor<person>(&person::age)
     );
 
     person p;

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -45,8 +45,17 @@ namespace cmoh {
  * since the cmoh system relies on each attribute declaration being another
  * type.
  *
- * The attributes themselves are not bound to a C++ type. Attributes may be
- * grouped together in namespaces or stucts, each representing an interface.
+ * The attributes themselves are not bound to a C++ type. Attributes do,
+ * however, provide the `accessor()` static method for creating appropriate
+ * types of accessors for accessing attributes in objects of a specific C++
+ * type. These accessors provide a method for getting the attribute's value and
+ * may provide a method for setting the attribute:
+ *
+ *     type get(object_type const& obj) const;
+ *     void set(object_type& obj, type&& value);
+ *
+ * Attributes may be grouped together in namespaces or stucts, each representing
+ * an interface.
  */
 template <
     typename Attr ///< type of the attribute itself

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -55,6 +55,16 @@ struct attribute {
     typedef typename std::remove_cv<Attr>::type type;
     static constexpr bool is_const = std::is_const<Attr>::value;
 
+    /**
+     * Attribute accessor using methods
+     *
+     * This accessor provides access to the attribute via methods of the target
+     * C++ struct/class. It is constructed from an appropriate getter and,
+     * optionally, a setter.
+     *
+     * Users are discouraged from constructing method accessors directly. Use
+     * one of the `accessor()` overloads provided by the attribute instead.
+     */
     template <
         typename ObjType, ///< type of the class or struct with the attribute
         typename SetterArg ///< effective type of the setter argument

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -94,9 +94,48 @@ struct attribute {
             (obj.*_setter)(std::forward<type>(value));
         }
     private:
-        const getter _getter;
-        const setter _setter;
+        getter _getter;
+        setter _setter;
     };
+
+    // overload for creating a method accessor
+    template <
+        typename ObjType ///< type of the class or struct with the attribute
+    >
+    static
+    method_accessor<ObjType, type>
+    accessor(
+        typename method_accessor<ObjType,type>::getter getter,
+        typename method_accessor<ObjType,type>::setter setter = nullptr
+    ) {
+        return method_accessor<ObjType,type>(getter, setter);
+    }
+
+    // overload for creating a method accessor
+    template <
+        typename ObjType ///< type of the class or struct with the attribute
+    >
+    static
+    method_accessor<ObjType, type const&>
+    accessor(
+        typename method_accessor<ObjType,type const&>::getter getter,
+        typename method_accessor<ObjType,type const&>::setter setter
+    ) {
+        return method_accessor<ObjType,type const&>(getter, setter);
+    }
+
+    // overload for creating a method accessor
+    template <
+        typename ObjType ///< type of the class or struct with the attribute
+    >
+    static
+    method_accessor<ObjType, type&&>
+    accessor(
+        typename method_accessor<ObjType,type&&>::getter getter,
+        typename method_accessor<ObjType,type&&>::setter setter
+    ) {
+        return method_accessor<ObjType,type&&>(getter, setter);
+    }
 };
 }
 

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -122,6 +122,7 @@ struct attribute {
         typename ObjType ///< type of the class or struct with the attribute
     >
     static
+    constexpr
     method_accessor<ObjType, type>
     accessor(
         typename method_accessor<ObjType,type>::getter getter,
@@ -135,6 +136,7 @@ struct attribute {
         typename ObjType ///< type of the class or struct with the attribute
     >
     static
+    constexpr
     method_accessor<ObjType, type const&>
     accessor(
         typename method_accessor<ObjType,type const&>::getter getter,
@@ -148,6 +150,7 @@ struct attribute {
         typename ObjType ///< type of the class or struct with the attribute
     >
     static
+    constexpr
     method_accessor<ObjType, type&&>
     accessor(
         typename method_accessor<ObjType,type&&>::getter getter,


### PR DESCRIPTION
The original attribute access via methods is confined regarding the setters. Only setters accepting a const reference is possible. This is not ideal.
This PR solves this problem and adds a unified way for constructing acceptors of different types. On the downside, the methods are now set at runtime.
