### PR TITLE
Optimize accessor bundle factory

### DIFF
--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -185,7 +185,7 @@ accessor_bundle<Accessors...>
 bundle(
     Accessors... accessors ///< accessors to bundle
 ) {
-    return accessor_bundle<Accessors...>(accessors...);
+    return accessor_bundle<Accessors...>(std::forward<Accessors>(accessors)...);
 }
 
 

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -79,8 +79,9 @@ public:
         "All accessors in a bundle must have the same object type"
     );
 
-    accessor_bundle(accessor accessor, Accessors... accessors) :
-            _accessor(accessor), _next(accessors...) {};
+    accessor_bundle(accessor current, Accessors... accessors) :
+            _accessor(std::forward<accessor>(current)),
+            _next(std::forward<Accessors>(accessors)...) {};
     accessor_bundle(accessor_bundle const&) = default;
     accessor_bundle(accessor_bundle&&) = default;
     accessor_bundle() = delete;

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -181,6 +181,8 @@ public:
 template <
     typename ...Accessors
 >
+constexpr
+const
 accessor_bundle<Accessors...>
 bundle(
     Accessors... accessors ///< accessors to bundle


### PR DESCRIPTION
This PR brings a few enhancements for `cmoh::bundle()`.
