### PR TITLE
Add exports via CMake and pkg-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Testing
 cmake_install.cmake
 install_manifest.txt
 
+# ignore PC file
+*.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,19 @@ target_include_directories(cmoh INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-install(
-    DIRECTORY include/cmoh/
-    DESTINATION include/cmoh
-    FILES_MATCHING PATTERN "*.hpp"
-)
 
 
 # examples/tests
 enable_testing()
 add_subdirectory(examples)
 add_subdirectory(test)
+
+
+# installation
+install(
+    DIRECTORY include/cmoh/
+    DESTINATION include/cmoh
+    FILES_MATCHING PATTERN "*.hpp"
+)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,4 +36,5 @@ install(EXPORT cmoh DESTINATION lib)
 
 # Pkg-config export
 configure_file(cmoh.pc.in cmoh.pc @ONLY)
+install(FILES cmoh.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,6 @@ install(
 install(TARGETS cmoh EXPORT cmoh PUBLIC_HEADER)
 install(EXPORT cmoh DESTINATION lib)
 
+# Pkg-config export
+configure_file(cmoh.pc.in cmoh.pc @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,4 +26,12 @@ install(
     FILES_MATCHING PATTERN "*.hpp"
 )
 
+# CMake specific export
+#
+# Because of CMake being a bitch when it comes to non-stndart use-cases, we
+# have to have this dummy target which we can't even use to install the
+# headers
+install(TARGETS cmoh EXPORT cmoh PUBLIC_HEADER)
+install(EXPORT cmoh DESTINATION lib)
+
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ are done from a user's point of view.
 Using this library
 ------------------
 
-As this is a header-only library, no linking is required. Make sure you add
-`<installation_prefix>/include` to your include directories. Support for CMake
-and pkg-config will follow at some point.
+As this is a header-only library, no linking is required. Both a CMake module
+and a pkg-config-file are installed along with the header files. The library is
+called "cmoh" in both cases. If you are using neither CMake nor pkg-config-based
+setups, add `<installation_prefix>/include` to your include directories.
 
 
 Dependencies

--- a/cmoh.pc.in
+++ b/cmoh.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: cmoh
+Description: C++ Meta Object Helpers
+Version: @PROJECT_VERSION@
+URL: http://github.com/neithernut/cmoh
+
+Requires:
+Cflags: -I${includedir}
+


### PR DESCRIPTION
Resolves #15 and #16.
`pkg-config` still doesn't tell us the include directory when installing to some weird prefix. Will investigate further.
