### PR TITLE
Move accessors to new namespace

### DIFF
--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -107,8 +107,8 @@ public:
 /**
  * Check whether an accessor accesses a specific attribute
  *
- * This checks whether the accessor provided features a type `attr` identical to
- * the attribute provided.
+ * This checks whether the accessor provided features a type `attribute`
+ * identical to the attribute provided.
  */
 template <
     typename Accessor, ///< accessor to test for the attribute
@@ -125,8 +125,8 @@ template <
 struct accesses_attribute<
     Accessor,
     Attribute,
-    util::void_t<typename Accessor::attr>
-> : std::is_same<Attribute, typename Accessor::attr> {};
+    util::void_t<typename Accessor::attribute>
+> : std::is_same<Attribute, typename Accessor::attribute> {};
 
 
 /**

--- a/include/cmoh/accessors/attribute/by_method.hpp
+++ b/include/cmoh/accessors/attribute/by_method.hpp
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_ATTRIBUTE_BY_METHOD_HPP__
+#define CMOH_ATTRIBUTE_BY_METHOD_HPP__
+
+
+// std includes
+#include <type_traits>
+#include <utility>
+
+
+namespace cmoh {
+namespace accessors {
+namespace attribute {
+
+
+/**
+ * Attribute accessor using methods
+ *
+ * This accessor provides access to the attribute via methods of the target
+ * C++ struct/class. It is constructed from an appropriate getter and,
+ * optionally, a setter.
+ *
+ * Users are discouraged from constructing method accessors directly. Use
+ * one of the `accessor()` overloads provided by the attribute instead.
+ */
+template <
+    typename Attribute, ///< attribute type being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename GetterVal, ///< type of the value returned from the getter
+    typename SetterArg ///< effective type of the setter argument
+>
+struct by_method {
+    typedef Attribute attribute; ///< type of attribute being accessed
+    typedef ObjType object_type; ///< object being accessed
+
+    typedef GetterVal(object_type::* getter)() const;
+    typedef void(object_type::* setter)(SetterArg);
+
+
+    static_assert(
+        std::is_convertible<GetterVal, typename attribute::type>::value,
+        "Value returned by getter is not convertible to attribute type"
+    );
+    static_assert(
+        std::is_convertible<typename attribute::type, SetterArg>::value,
+        "Attribute's type is not convertible to type required by setter"
+    );
+
+
+    by_method(getter getter, setter setter = nullptr)
+        : _getter(getter), _setter(setter) {};
+    by_method(by_method const&) = default;
+    by_method(by_method&&) = default;
+
+    /**
+     * Get the attribute from an object
+     *
+     * \returns the attribute's value
+     */
+    typename attribute::type
+    get(
+        object_type const& obj ///< object from which to get the value
+    ) const {
+        return (obj.*_getter)();
+    }
+
+    /**
+     * Set the attribute on an object
+     */
+    void
+    set(
+        object_type& obj, ///< object on which to set the attribute
+        typename attribute::type&& value ///< value to set
+    ) const {
+        (obj.*_setter)(std::forward<typename attribute::type>(value));
+    }
+private:
+    getter _getter;
+    setter _setter;
+};
+
+
+}
+}
+}
+
+
+
+#endif

--- a/include/cmoh/accessors/attribute/by_method.hpp
+++ b/include/cmoh/accessors/attribute/by_method.hpp
@@ -102,6 +102,75 @@ private:
 };
 
 
+// accessor factory overlaods for the `cmoh::accessor::attribute::by_method`
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value>::getter getter
+) {
+    return by_method<Attribute, ObjType, Value, Value>(getter, nullptr);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value>(getter, setter);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value const&>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value const&>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value const&>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value const&>(getter, setter);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value&&>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value&&>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value&&>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value&&>(getter, setter);
+}
+
+
 }
 }
 }

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -30,6 +30,10 @@
 #include <utility>
 
 
+// local includes
+#include <cmoh/accessors/attribute/by_method.hpp>
+
+
 namespace cmoh {
 
 
@@ -64,70 +68,10 @@ struct attribute {
     typedef typename std::remove_cv<Attr>::type type;
     static constexpr bool is_const = std::is_const<Attr>::value;
 
-    /**
-     * Attribute accessor using methods
-     *
-     * This accessor provides access to the attribute via methods of the target
-     * C++ struct/class. It is constructed from an appropriate getter and,
-     * optionally, a setter.
-     *
-     * Users are discouraged from constructing method accessors directly. Use
-     * one of the `accessor()` overloads provided by the attribute instead.
-     */
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename GetterVal, ///< type of the value returned from the getter
-        typename SetterArg ///< effective type of the setter argument
-    >
-    struct method_accessor {
-        typedef attribute attr; ///< attribute being accessed
-        typedef ObjType object_type; ///< object being accessed
 
-        typedef GetterVal(object_type::* getter)() const;
-        typedef void(object_type::* setter)(SetterArg);
-
-
-        static_assert(
-            std::is_convertible<GetterVal, attr::type>::value,
-            "Value returned by getter is not convertible to attribute type"
-        );
-        static_assert(
-            std::is_convertible<attr::type, SetterArg>::value,
-            "Attribute's type is not convertible to type required by setter"
-        );
-
-
-        method_accessor(getter getter, setter setter = nullptr)
-            : _getter(getter), _setter(setter) {};
-        method_accessor(method_accessor const&) = default;
-        method_accessor(method_accessor&&) = default;
-
-        /**
-         * Get the attribute from an object
-         *
-         * \returns the attribute's value
-         */
-        attr::type
-        get(
-            object_type const& obj ///< object from which to get the value
-        ) const {
-            return (obj.*_getter)();
-        }
-
-        /**
-         * Set the attribute on an object
-         */
-        void
-        set(
-            object_type& obj, ///< object on which to set the attribute
-            attr::type&& value ///< value to set
-        ) const {
-            (obj.*_setter)(std::forward<attr::type>(value));
-        }
-    private:
-        getter _getter;
-        setter _setter;
-    };
+    template <typename Obj, typename GetterVal, typename SetterVal>
+    using method_accessor =
+        accessors::attribute::by_method<attribute, Obj, GetterVal, SetterVal>;
 
     // overload for creating a method accessor
     template <

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -69,79 +69,29 @@ struct attribute {
     static constexpr bool is_const = std::is_const<Attr>::value;
 
 
-    template <typename Obj, typename GetterVal, typename SetterVal>
-    using method_accessor =
-        accessors::attribute::by_method<attribute, Obj, GetterVal, SetterVal>;
-
-    // overload for creating a method accessor
+    /**
+     * Get an accessor for the attribute
+     *
+     * This methos creates a new accessor using the facilities passed to it.
+     * That accessor may be used to access the attribute in a concrete C++
+     * struct or class of type `ObjType`.
+     */
     template <
         typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
+        typename Value = type, ///< type of the value in the concrete C++ type
+        typename... Args ///< arguments forwarded to the factory
     >
     static
     constexpr
-    typename std::enable_if<
-        is_const,
-        method_accessor<ObjType, Value, Value>
-    >::type
+    decltype(accessors::attribute::make_accessor<attribute, ObjType, Value>(
+        std::declval<Args>()...
+    ))
     accessor(
-        typename method_accessor<ObjType, Value, Value>::getter getter
+        Args&&... args
     ) {
-        return method_accessor<ObjType, Value, Value>(getter, nullptr);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value>::getter getter,
-        typename method_accessor<ObjType, Value, Value>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value>(getter, setter);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value const&>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value const&>::getter getter,
-        typename method_accessor<ObjType, Value, Value const&>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value const&>(getter, setter);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value&&>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value&&>::getter getter,
-        typename method_accessor<ObjType, Value, Value&&>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value&&>(getter, setter);
+        return accessors::attribute::make_accessor<attribute, ObjType, Value>(
+            std::forward<Args>(args)...
+        );
     }
 
 


### PR DESCRIPTION
This PR moves the existing attribute accessor to a new namespace, in preparation for #17, #18 and #33 and to make things more modular. This will also help greatly once we to #21.
