### PR TITLE
Encapsulate accessors in namespace

### DIFF
--- a/examples/attributes_example.cpp
+++ b/examples/attributes_example.cpp
@@ -27,9 +27,9 @@
 #include <iostream>
 
 // CMOH includes
-#include <cmoh/attribute.hpp>
 #include <cmoh/accessor_bundle.hpp>
-#include <cmoh/constructor.hpp>
+#include <cmoh/attribute.hpp>
+#include <cmoh/factory.hpp>
 
 // local includes
 #include "person.hpp"
@@ -46,12 +46,12 @@ int main(int argc, char* argv[]) {
     // From the attributes we pull accessors for a concrete C++ type and bundle
     // them in an accessor bundle.
     auto accessors = bundle(
-        cmoh::constructor<person, birthday>(),
+        cmoh::factory<person, birthday>(),
         name::accessor<person>(&person::name, &person::set_name),
         age::accessor<person>(&person::age)
     );
 
-    person p = accessors.construct<birthday, name>(
+    person p = accessors.create<birthday, name>(
         std::chrono::system_clock::now() - std::chrono::hours(24),
         "Hans"
     );

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -163,18 +163,18 @@ struct accessor_bundle {
         typename ...Attributes ///< attributes from which to construct an object
     >
     object_type
-    construct(
+    create(
         typename Attributes::type&&... values ///< value to set
     ) const {
-        auto constructor = _accessors.
+        auto factory = _accessors.
             template get<is_initializable_from<Accessors, Attributes...>...>();
 
         // construct the object itself
-        auto retval{constructor.template construct<Attributes...>(
+        auto retval{factory.template create<Attributes...>(
             std::forward<typename Attributes::type>(values)...
         )};
 
-        initialize_if_unused<decltype(constructor), Attributes...>(
+        initialize_if_unused<decltype(factory), Attributes...>(
             retval,
             std::forward<typename Attributes::type>(values)...
         );

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -107,8 +107,8 @@ public:
 /**
  * Check whether an accessor accesses a specific attribute
  *
- * This checks whether the accessor provided features a type `attr` identical to
- * the attribute provided.
+ * This checks whether the accessor provided features a type `attribute`
+ * identical to the attribute provided.
  */
 template <
     typename Accessor, ///< accessor to test for the attribute
@@ -125,8 +125,8 @@ template <
 struct accesses_attribute<
     Accessor,
     Attribute,
-    util::void_t<typename Accessor::attr>
-> : std::is_same<Attribute, typename Accessor::attr> {};
+    util::void_t<typename Accessor::attribute>
+> : std::is_same<Attribute, typename Accessor::attribute> {};
 
 
 /**

--- a/include/cmoh/accessors/attribute/by_method.hpp
+++ b/include/cmoh/accessors/attribute/by_method.hpp
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_ATTRIBUTE_BY_METHOD_HPP__
+#define CMOH_ATTRIBUTE_BY_METHOD_HPP__
+
+
+// std includes
+#include <type_traits>
+#include <utility>
+
+
+namespace cmoh {
+namespace accessors {
+namespace attribute {
+
+
+/**
+ * Attribute accessor using methods
+ *
+ * This accessor provides access to the attribute via methods of the target
+ * C++ struct/class. It is constructed from an appropriate getter and,
+ * optionally, a setter.
+ *
+ * Users are discouraged from constructing method accessors directly. Use
+ * one of the `accessor()` overloads provided by the attribute instead.
+ */
+template <
+    typename Attribute, ///< attribute type being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename GetterVal, ///< type of the value returned from the getter
+    typename SetterArg ///< effective type of the setter argument
+>
+struct by_method {
+    typedef Attribute attribute; ///< type of attribute being accessed
+    typedef ObjType object_type; ///< object being accessed
+
+    typedef GetterVal(object_type::* getter)() const;
+    typedef void(object_type::* setter)(SetterArg);
+
+
+    static_assert(
+        std::is_convertible<GetterVal, typename attribute::type>::value,
+        "Value returned by getter is not convertible to attribute type"
+    );
+    static_assert(
+        std::is_convertible<typename attribute::type, SetterArg>::value,
+        "Attribute's type is not convertible to type required by setter"
+    );
+
+
+    by_method(getter getter, setter setter = nullptr)
+        : _getter(getter), _setter(setter) {};
+    by_method(by_method const&) = default;
+    by_method(by_method&&) = default;
+
+    /**
+     * Get the attribute from an object
+     *
+     * \returns the attribute's value
+     */
+    typename attribute::type
+    get(
+        object_type const& obj ///< object from which to get the value
+    ) const {
+        return (obj.*_getter)();
+    }
+
+    /**
+     * Set the attribute on an object
+     */
+    void
+    set(
+        object_type& obj, ///< object on which to set the attribute
+        typename attribute::type&& value ///< value to set
+    ) const {
+        (obj.*_setter)(std::forward<typename attribute::type>(value));
+    }
+private:
+    getter _getter;
+    setter _setter;
+};
+
+
+}
+}
+}
+
+
+
+#endif

--- a/include/cmoh/accessors/attribute/by_method.hpp
+++ b/include/cmoh/accessors/attribute/by_method.hpp
@@ -102,6 +102,75 @@ private:
 };
 
 
+// accessor factory overlaods for the `cmoh::accessor::attribute::by_method`
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value>::getter getter
+) {
+    return by_method<Attribute, ObjType, Value, Value>(getter, nullptr);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value>(getter, setter);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value const&>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value const&>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value const&>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value const&>(getter, setter);
+}
+
+template <
+    typename Attribute, ///< attribute being accessed
+    typename ObjType, ///< type of the class or struct with the attribute
+    typename Value ///< type of the value in the concrete C++ type
+>
+constexpr
+typename std::enable_if<
+    !Attribute::is_const,
+    by_method<Attribute, ObjType, Value, Value&&>
+>::type
+make_accessor(
+    typename by_method<Attribute, ObjType, Value, Value&&>::getter getter,
+    typename by_method<Attribute, ObjType, Value, Value&&>::setter setter
+) {
+    return by_method<Attribute, ObjType, Value, Value&&>(getter, setter);
+}
+
+
 }
 }
 }

--- a/include/cmoh/accessors/factory/abstract_factory.hpp
+++ b/include/cmoh/accessors/factory/abstract_factory.hpp
@@ -21,15 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef CMOH_ACCESSORS_FACTORY_CONSTRUCTOR_HPP__
-#define CMOH_ACCESSORS_FACTORY_CONSTRUCTOR_HPP__
+#ifndef CMOH_ACCESSORS_FACTORY_ABSTRACT_FACTORY_HPP__
+#define CMOH_ACCESSORS_FACTORY_ABSTRACT_FACTORY_HPP__
 
 
 // std includes
 #include <utility>
 
 // local includes
-#include <cmoh/accessors/factory/abstract_factory.hpp>
+#include <cmoh/utils.hpp>
 
 
 namespace cmoh {
@@ -38,32 +38,38 @@ namespace factory {
 
 
 /**
- * Factory using a constructor
+ * Object factory wrapper base
  *
- * Using this template, a programmer may specify from which attributes a
- * specific C++ type may be constructed.
- *
- * Users are discouraged from constructing method accessors directly. Use
- * one of the `cmoh::factory()` overloads provided by the attribute instead.
+ * This template provides a few utilities and other members which are expected
+ * from a factory.
  */
 template <
-    typename ObjType, ///< type of the class or struct to be constructed
     typename ...Attributes ///< attributes fed to the constructor
 >
-struct constructor : abstract_factory<Attributes...> {
-    typedef ObjType object_type; ///< type being constructed
-
+struct abstract_factory {
+    /**
+     * Check whether the constructor can be invoked using some attributes
+     *
+     * Instantiations provide a member `value` which is `true` if the attributes
+     * are sufficient for constructing an object and false otherwise.
+     */
     template <
-        typename ...PassedAttributes ///< attrbiutes availible for construction
+        typename ...PassedAttributes ///< attributes availible for construction
     >
-    object_type
-    create(typename PassedAttributes::type&&... arguments) const {
-        return object_type{
-            Attributes::template select<PassedAttributes...>(
-                std::forward<typename PassedAttributes::type>(arguments)...
-            )...
-        };
-    }
+    using is_initializable_from = util::conjunction<
+        typename util::contains<Attributes, PassedAttributes...>...
+    >;
+
+    /**
+     * Check whether a specific attribute is used by this constructor
+     *
+     * Instantiations provide a member `value` which is `true` if the attribute
+     * is used for constructing an object and false otherwise.
+     */
+    template <
+        typename Attribute
+    >
+    using uses = util::contains<Attribute, Attributes...>;
 };
 
 

--- a/include/cmoh/accessors/factory/constructor.hpp
+++ b/include/cmoh/accessors/factory/constructor.hpp
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef CMOH_CONSTRUCTOR_HPP__
-#define CMOH_CONSTRUCTOR_HPP__
+#ifndef CMOH_ACCESSORS_FACTORY_CONSTRUCTOR_HPP__
+#define CMOH_ACCESSORS_FACTORY_CONSTRUCTOR_HPP__
 
 
 // std includes
@@ -33,6 +33,8 @@
 
 
 namespace cmoh {
+namespace accessors {
+namespace factory {
 
 
 /**
@@ -87,6 +89,8 @@ struct constructor {
 };
 
 
+}
+}
 }
 
 

--- a/include/cmoh/accessors/factory/constructor.hpp
+++ b/include/cmoh/accessors/factory/constructor.hpp
@@ -69,6 +69,20 @@ struct constructor : abstract_factory<Attributes...> {
 
 }
 }
+
+
+// factory factory overload for constructors
+template <
+    typename ObjType,
+    typename ...Attributes
+>
+constexpr
+accessors::factory::constructor<ObjType, Attributes...>
+factory() {
+    return accessors::factory::constructor<ObjType, Attributes...>();
+}
+
+
 }
 
 

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_ACCESSORS_UTILS_HPP__
+#define CMOH_ACCESSORS_UTILS_HPP__
+
+
+// std includes
+#include <type_traits>
+
+
+// local includes
+#include <cmoh/utils.hpp>
+
+
+namespace cmoh {
+namespace accessors {
+
+
+/**
+ * Check whether a supposed accessor is a factory
+ *
+ * Detection is performed by detecting the `is_initializable_from` member.
+ */
+template <
+    typename Accessor, ///< accessor to check
+    typename = void
+>
+struct is_factory : std::false_type {};
+
+// Specialization for factories
+template <
+    typename Accessor
+>
+struct is_factory<
+    Accessor,
+    util::void_t<typename Accessor::template is_initializable_from<>>
+> : std::true_type {};
+
+
+/**
+ * Check whether a supposed accessor is an attribute accessor
+ *
+ * Detection is performed by detecting the `attribute` member.
+ */
+template <
+    typename Accessor, ///< accessor to check
+    typename = void
+>
+struct is_attribute_accessor : std::false_type {};
+
+// Specialization for attributes
+template <
+    typename Accessor
+>
+struct is_attribute_accessor<
+    Accessor,
+    util::void_t<typename Accessor::attribute>
+> : std::true_type {};
+
+
+/**
+ * Enumeration type for detecting different types of accessors
+ */
+enum accessor_type {
+    none, ///< not an accessor
+    factory_implementation, ///< a factory
+    attribute_accessor ///< an attribute accessor
+};
+
+
+/**
+ * Meta function for querying the accessor type of a type
+ *
+ * Returns the `accessor_type` associated with the `Accessor` supplied via the
+ * `value` member.
+ */
+template <
+    typename Accessor
+>
+using accessor_type_of = std::integral_constant<
+    accessor_type,
+    is_factory<Accessor>::value ? factory_implementation :
+    is_attribute_accessor<Accessor>::value ? attribute_accessor :
+    none
+>;
+
+
+}
+}
+
+
+
+
+#endif

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -106,6 +106,43 @@ using accessor_type_of = std::integral_constant<
 >;
 
 
+/**
+ * Query an accessor's underlying type
+ *
+ * Returns an accessor's underlying property (e.g. the type containing the
+ * members `key_type` and `key`) or void via the member `type`.
+ */
+template <
+    typename Accessor
+>
+struct property {
+private:
+    template <
+        typename T,
+        accessor_type acc_type
+    >
+    struct helper {
+        typedef void type;
+    };
+
+    template <typename T>
+    struct helper<T, factory_implementation> {
+        typedef T type;
+    };
+
+    template <typename T>
+    struct helper<T, attribute_accessor> {
+        typedef typename T::attribute type;
+    };
+
+public:
+    typedef typename helper<
+        Accessor,
+        accessor_type_of<Accessor>::value
+    >::type type;
+};
+
+
 }
 }
 

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -30,6 +30,10 @@
 #include <utility>
 
 
+// local includes
+#include <cmoh/accessors/attribute/by_method.hpp>
+
+
 namespace cmoh {
 
 
@@ -64,70 +68,10 @@ struct attribute {
     typedef typename std::remove_cv<Attr>::type type;
     static constexpr bool is_const = std::is_const<Attr>::value;
 
-    /**
-     * Attribute accessor using methods
-     *
-     * This accessor provides access to the attribute via methods of the target
-     * C++ struct/class. It is constructed from an appropriate getter and,
-     * optionally, a setter.
-     *
-     * Users are discouraged from constructing method accessors directly. Use
-     * one of the `accessor()` overloads provided by the attribute instead.
-     */
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename GetterVal, ///< type of the value returned from the getter
-        typename SetterArg ///< effective type of the setter argument
-    >
-    struct method_accessor {
-        typedef attribute attr; ///< attribute being accessed
-        typedef ObjType object_type; ///< object being accessed
 
-        typedef GetterVal(object_type::* getter)() const;
-        typedef void(object_type::* setter)(SetterArg);
-
-
-        static_assert(
-            std::is_convertible<GetterVal, attr::type>::value,
-            "Value returned by getter is not convertible to attribute type"
-        );
-        static_assert(
-            std::is_convertible<attr::type, SetterArg>::value,
-            "Attribute's type is not convertible to type required by setter"
-        );
-
-
-        method_accessor(getter getter, setter setter = nullptr)
-            : _getter(getter), _setter(setter) {};
-        method_accessor(method_accessor const&) = default;
-        method_accessor(method_accessor&&) = default;
-
-        /**
-         * Get the attribute from an object
-         *
-         * \returns the attribute's value
-         */
-        attr::type
-        get(
-            object_type const& obj ///< object from which to get the value
-        ) const {
-            return (obj.*_getter)();
-        }
-
-        /**
-         * Set the attribute on an object
-         */
-        void
-        set(
-            object_type& obj, ///< object on which to set the attribute
-            attr::type&& value ///< value to set
-        ) const {
-            (obj.*_setter)(std::forward<attr::type>(value));
-        }
-    private:
-        getter _getter;
-        setter _setter;
-    };
+    template <typename Obj, typename GetterVal, typename SetterVal>
+    using method_accessor =
+        accessors::attribute::by_method<attribute, Obj, GetterVal, SetterVal>;
 
     // overload for creating a method accessor
     template <

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -69,79 +69,29 @@ struct attribute {
     static constexpr bool is_const = std::is_const<Attr>::value;
 
 
-    template <typename Obj, typename GetterVal, typename SetterVal>
-    using method_accessor =
-        accessors::attribute::by_method<attribute, Obj, GetterVal, SetterVal>;
-
-    // overload for creating a method accessor
+    /**
+     * Get an accessor for the attribute
+     *
+     * This methos creates a new accessor using the facilities passed to it.
+     * That accessor may be used to access the attribute in a concrete C++
+     * struct or class of type `ObjType`.
+     */
     template <
         typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
+        typename Value = type, ///< type of the value in the concrete C++ type
+        typename... Args ///< arguments forwarded to the factory
     >
     static
     constexpr
-    typename std::enable_if<
-        is_const,
-        method_accessor<ObjType, Value, Value>
-    >::type
+    decltype(accessors::attribute::make_accessor<attribute, ObjType, Value>(
+        std::declval<Args>()...
+    ))
     accessor(
-        typename method_accessor<ObjType, Value, Value>::getter getter
+        Args&&... args
     ) {
-        return method_accessor<ObjType, Value, Value>(getter, nullptr);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value>::getter getter,
-        typename method_accessor<ObjType, Value, Value>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value>(getter, setter);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value const&>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value const&>::getter getter,
-        typename method_accessor<ObjType, Value, Value const&>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value const&>(getter, setter);
-    }
-
-    // overload for creating a method accessor
-    template <
-        typename ObjType, ///< type of the class or struct with the attribute
-        typename Value = type
-    >
-    static
-    constexpr
-    typename std::enable_if<
-        !is_const,
-        method_accessor<ObjType, Value, Value&&>
-    >::type
-    accessor(
-        typename method_accessor<ObjType, Value, Value&&>::getter getter,
-        typename method_accessor<ObjType, Value, Value&&>::setter setter
-    ) {
-        return method_accessor<ObjType, Value, Value&&>(getter, setter);
+        return accessors::attribute::make_accessor<attribute, ObjType, Value>(
+            std::forward<Args>(args)...
+        );
     }
 
 

--- a/include/cmoh/factory.hpp
+++ b/include/cmoh/factory.hpp
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_FACTORY_HPP__
+#define CMOH_FACTORY_HPP__
+
+
+// local includes
+#include <cmoh/accessors/factory/constructor.hpp>
+
+
+#endif

--- a/include/cmoh/selectable_items.hpp
+++ b/include/cmoh/selectable_items.hpp
@@ -58,6 +58,7 @@ template <
     typename ...Types ///< types of the items held by the container
 >
 struct selectable_items {
+    template <typename...> using type_of = void;
     template <typename...> void get() {}
 };
 
@@ -77,7 +78,24 @@ private:
     next _next;
 
 
+    // helper for type_of
+    template <typename ...BoolTypes>
+    struct type_of_helper;
+
+    template <typename BoolType0, typename ...BoolTypes>
+    struct type_of_helper<BoolType0, BoolTypes...> : std::conditional<
+        BoolType0::value,
+        value,
+        typename next::template type_of<BoolTypes...>
+    > {};
+
 public:
+    template <
+        typename ...BoolTypes
+    >
+    using type_of = typename type_of_helper<BoolTypes...>::type;
+
+
     selectable_items(value&& current, Types... values) :
             _value(std::forward<value>(current)),
             _next(std::forward<Types>(values)...) {};

--- a/include/cmoh/selectable_items.hpp
+++ b/include/cmoh/selectable_items.hpp
@@ -122,7 +122,7 @@ public:
     >
     typename std::enable_if<
         !BoolType0::value,
-        decltype(_next.template get<BoolTypes...>())
+        typename next::template type_of<BoolTypes...>
     >::type
     get() const noexcept {
         return _next.template get<BoolTypes...>();

--- a/include/cmoh/utils.hpp
+++ b/include/cmoh/utils.hpp
@@ -133,8 +133,10 @@ using void_t = void;
 /**
  * Meta type extracting the common type of a parameter pack
  *
- * If all `Types` are identical, the type will be exported as the member `type`.
- * If not all parameters are identical, a compile time error will be issued.
+ * All `Types` that are identical to `void` are ignored. If all the remaining
+ * `Types` are identical, the type will be exported as the member `type`.
+ * If not all parameters are identical or `void`, a compile time error will be
+ * issued.
  */
 template <
     typename ...Types ///< types to unify
@@ -151,9 +153,18 @@ template <
 struct common_type<Type0, Types...> {
     typedef Type0 type;
     static_assert(
-        std::is_same<type, typename common_type<Types...>::type>::value,
+        std::is_same<typename common_type<Types...>::type, type>::value ||
+        std::is_void<typename common_type<Types...>::type>::value,
         "Types are not identical"
     );
+};
+
+// Specialization for the void type
+template <
+    typename ...Types
+>
+struct common_type<void, Types...> {
+    typedef typename common_type<Types...>::type type;
 };
 
 // Specialization for exactly one parameter
@@ -162,6 +173,12 @@ template <
 >
 struct common_type<Type> {
     typedef Type type;
+};
+
+// Otherwise pointless specialization to avoid "ambogious specialization"
+template <>
+struct common_type<void> {
+    typedef void type;
 };
 
 


### PR DESCRIPTION
This PR encapsulates accessors in a new namespace `cmoh::accessors` and sub-manespaces. It also introduces a bunch of utilities to ease the use of accessors as well as an extension to existing utilities. In the long run, those will superseed the utilities currently contained in `accessor_bundle.hpp` prior to the declaration of `accessor_bundle`.

Blocks #45 and #48. Kinda a restart of #44, but not excactly.
