### PR TITLE
Add dynamic getter and setter

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 #ignore example executables
 attributes_example
+dynamic_key_example

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,8 +13,21 @@ add_test(
 )
 
 
+# dynamic key example
+add_executable(dynamic_key_example EXCLUDE_FROM_ALL
+    dynamic_key_example.cpp
+    person.cpp
+)
+target_link_libraries(dynamic_key_example cmoh)
+add_test(
+    NAME dynamic_key
+    COMMAND dynamic_key_example --exe $<TARGET_FILE:dynamic_key_example>
+)
+
+
 # provide a convenience target to build all examples
 add_custom_target(examples DEPENDS
     attributes_example
+    dynamic_key_example
 )
 

--- a/examples/dynamic_key_example.cpp
+++ b/examples/dynamic_key_example.cpp
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+// std includes
+#include <iostream>
+#include <cassert>
+
+// CMOH includes
+#include <cmoh/accessor_bundle.hpp>
+#include <cmoh/attribute.hpp>
+#include <cmoh/factory.hpp>
+
+// local includes
+#include "person.hpp"
+
+// we _always_ want assertions
+#undef NDEBUG
+
+
+
+
+// Like in the attribute example, we declare an attribute
+using name_attr = cmoh::attribute<int, 1, std::string>;
+
+
+
+
+int main(int argc, char* argv[]) {
+    // We specify how to access the attribute
+    auto accessors = bundle(
+        name_attr::accessor<person>(&person::name, &person::set_name)
+    );
+
+    // We create a new person to play with
+    person p(std::chrono::system_clock::now());
+
+    // We give the person a name
+    assert(accessors.set<std::string>(p, 1, std::string("Lisa")));
+
+    {
+        // Now we try to retrieve it
+        auto name = accessors.get<std::string>(p, 1);
+        std::cout << "Name: " << name.value_or("unknown") << std::endl;
+        assert(name.has_value());
+    }
+
+    {
+        // We want to retrieve the name again, but this time with another key
+        auto name = accessors.get<std::string>(p, 2);
+        std::cout << "Name: " << name.value_or("unknown") << std::endl;
+        assert(!name.has_value());
+    }
+
+    return 0;
+}
+

--- a/include/cmoh/optional.hpp
+++ b/include/cmoh/optional.hpp
@@ -1,0 +1,208 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_OPTIONAL_HPP__
+#define CMOH_OPTIONAL_HPP__
+
+
+// std includes
+#include <utility>
+
+
+namespace cmoh {
+
+
+/**
+ * Predefinition of the C++17 std::optional type
+ *
+ * This template provides an optional type which is modelled after the
+ * std::optional which is part of the C++17 standart proposal. Note that
+ * only a subset of the interface is provided.
+ *
+ * For documentation, refer to the C++17 proposal or your favorite STL
+ * documentation site.
+ */
+template <
+    class T
+>
+class optional {
+public:
+    typedef T value_type;
+
+
+    constexpr optional() : _has_data(false) {}
+
+    optional(optional const& other) : _has_data(other.has_value()) {
+        if (_has_data)
+            construct(*(other.value_ptr()));
+    }
+
+    optional(optional&& other) : _has_data(other.has_value()) {
+        if (_has_data)
+            construct(std::move(*(other.value_ptr())));
+    }
+
+    constexpr optional(value_type const& value) : _has_data(true) {
+        construct(value);
+    }
+
+    constexpr optional(value_type&& value) : _has_data(true) {
+        construct(std::move(value));
+    }
+
+
+    ~optional() {
+        destruct();
+    }
+
+
+    optional& operator=(optional const& other) {
+        destruct();
+        if ((_has_data = other.has_value()))
+            construct(*(other.value_ptr()));
+
+        return *this;
+    }
+
+    optional& operator=(optional&& other) {
+        destruct();
+        if ((_has_data = other.has_value()))
+            construct(std::move(*(other.value_ptr())));
+
+        return *this;
+    }
+
+    template <
+        typename U
+    >
+    optional& operator=(U&& value) {
+        destruct();
+        construct(std::forward<U>(value));
+        _has_data = true;
+
+        return *this;
+    }
+
+
+    constexpr const value_type* operator->() const {
+        return value_ptr();
+    }
+
+    constexpr value_type* operator->() {
+        return value_ptr();
+    }
+
+    constexpr value_type const& operator*() const {
+        return *value_ptr();
+    }
+
+    constexpr value_type& operator*() {
+        return *value_ptr();
+    }
+
+
+    constexpr explicit operator bool() const noexcept {
+        return has_value();
+    }
+
+    constexpr bool has_value() const noexcept {
+        return _has_data;
+    }
+
+
+    template <typename U>
+    constexpr T value_or(U&& default_value) const& {
+        if (has_value())
+            return **this;
+        return static_cast<T>(std::forward<U>(default_value));
+    }
+
+    template <typename U>
+    constexpr T value_or(U&& default_value) && {
+        if (has_value())
+            return std::move(**this);
+        return static_cast<T>(std::forward<U>(default_value));
+    }
+
+
+    void reset() noexcept {
+        destruct();
+        _has_data = false;
+    }
+
+
+    template <typename ...Args>
+    void emplace(Args&&... args) {
+        destruct();
+        construct(std::forward<Args>(args)...);
+        _has_data = true;
+    }
+
+    template <typename U, typename ...Args>
+    std::enable_if<
+        std::is_constructible<
+            value_type,
+            std::initializer_list<U>&,
+            Args&&...
+        >::value
+    >
+    emplace(std::initializer_list<U> ilist, Args&&... args) {
+        destruct();
+        construct(ilist, std::forward<Args>(args)...);
+        _has_data = true;
+    }
+
+
+private:
+    template <
+        typename ...Args
+    >
+    void construct(Args&&... args) {
+        new(value_ptr()) value_type(std::forward<Args>(args)...);
+    }
+
+    void destruct() noexcept {
+        if (has_value())
+            value_ptr()->value_type::~value_type();
+    }
+
+
+    constexpr value_type const* value_ptr() const noexcept {
+        return reinterpret_cast<value_type const*>(&_data[0]);
+    }
+
+    constexpr value_type* value_ptr() noexcept {
+        return reinterpret_cast<value_type*>(&_data[0]);
+    }
+
+
+    char _data[sizeof(T)];
+    bool _has_data;
+};
+
+
+}
+
+
+
+#endif

--- a/include/cmoh/optional.hpp
+++ b/include/cmoh/optional.hpp
@@ -25,6 +25,29 @@
 #define CMOH_OPTIONAL_HPP__
 
 
+// We try to detect whether a standard `optional` is availible, but only for
+// post-C++14 (we don't expect a C++14 STL to ship it).
+#if __cplusplus > 201402L
+# if __has_include(<optional>)
+#  define has_optional 1
+# elif __has_include(<experimental/optional>)
+#  define has_experimental_optional 1
+# endif
+#endif
+
+
+// Use one of the availible `optional` implementations
+#ifdef has_optional
+#include <optional>
+namespace cmoh { template <class T> using optional = std::optional<T>; }
+#elif has_experimental_optional
+#include <experimental/optional>
+namespace cmoh {
+    template <class T> using optional = std::experimental::optional<T>;
+}
+#else
+
+
 // std includes
 #include <utility>
 
@@ -205,4 +228,5 @@ private:
 
 
 
+#endif
 #endif

--- a/include/cmoh/properties.hpp
+++ b/include/cmoh/properties.hpp
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_PROPERTIES_HPP__
+#define CMOH_PROPERTIES_HPP__
+
+
+// local includes
+#include <cmoh/utils.hpp>
+
+
+namespace cmoh {
+namespace properties {
+
+
+/**
+ * Check whether a property is an attribute with a specific type
+ *
+ * If the property supplied is an attribute with the type `Type`, the static
+ * member `value` will be true. Otherwise, `value` will be false.
+ */
+template <
+    typename Property, ///< property to check
+    typename Type, ///< type to compare to
+    typename = void
+>
+struct is_attribute_with_type : std::false_type {};
+
+// Specialization for attributes
+template <
+    typename Property,
+    typename Type
+>
+struct is_attribute_with_type<
+    Property,
+    Type,
+    util::void_t<typename Property::type>
+> : std::is_same<typename Property::type, Type> {};
+
+
+}
+}
+
+
+#endif

--- a/include/cmoh/selectable_items.hpp
+++ b/include/cmoh/selectable_items.hpp
@@ -60,6 +60,18 @@ template <
 struct selectable_items {
     template <typename...> using type_of = void;
     template <typename...> void get() {}
+
+    /**
+     * Visit all items, optionally matching some compile time critirea
+     */
+    template <
+        typename Function,
+        typename ...BoolTypes
+    >
+    void
+    visit(
+        Function&& func ///< function to apply
+    ) const {}
 };
 
 // Specialization for at least one parameter
@@ -126,6 +138,66 @@ public:
     >::type
     get() const noexcept {
         return _next.template get<BoolTypes...>();
+    }
+
+
+    template <
+        typename Function,
+        typename BoolType0 = std::true_type,
+        typename ...BoolTypes
+    >
+    typename std::enable_if<BoolType0::value>::type
+    visit(
+        Function&& func
+    ) const {
+        func(_value);
+        _next.template visit<Function, BoolTypes...>(
+            std::forward<Function>(func)
+        );
+    }
+
+    template <
+        typename Function,
+        typename BoolType0 = std::true_type,
+        typename ...BoolTypes
+    >
+    typename std::enable_if<!BoolType0::value>::type
+    visit(
+        Function&& func
+    ) const {
+        _next.template visit<Function, BoolTypes...>(
+            std::forward<Function>(func)
+        );
+    }
+
+
+    template <
+        typename Function,
+        typename BoolType0 = std::true_type,
+        typename ...BoolTypes
+    >
+    typename std::enable_if<BoolType0::value>::type
+    visit(
+        Function&& func
+    ) {
+        func(_value);
+        _next.template visit<Function, BoolTypes...>(
+            std::forward<Function>(func)
+        );
+    }
+
+    template <
+        typename Function,
+        typename BoolType0 = std::true_type,
+        typename ...BoolTypes
+    >
+    typename std::enable_if<!BoolType0::value>::type
+    visit(
+        Function&& func
+    ) {
+        _next.template visit<Function, BoolTypes...>(
+            std::forward<Function>(func)
+        );
     }
 };
 


### PR DESCRIPTION
This PR adds dynamic getters and setters to `accessor_bundle` --dynamic meaning that the key doesn't have to be a compile-time constant. It also adds a few utilities which are required for the entire thing to work. All in all, this PR brings:
- [x] optional type
- [x] visitor methods in `selectable_items`
- [x] dynamic getters and setters
- [x] example demonstrating the new capability.

Resolves #46.
