### PR TITLE
Export properties' keys via a method, not a plain member

### DIFF
--- a/doc/Properties.md
+++ b/doc/Properties.md
@@ -12,8 +12,8 @@ specific parameters (see below for details), in that order.
 
 The key is used or addressing properties in an object. The idea is to use the
 key for binding a property to an external representation/an RPC interface in
-libraries. Hence, the key is always exported as `<property>::key` while the key
-type is exported as the member type `<property>::key_type`.
+libraries. Hence, the key is always exported as `<property>::key()` while the
+key type is exported as the member type `<property>::key_type`.
 
 Properties also expose a static method `accessor()`, which serves as a factory
 for (potentially diverse) accessor types available for the type of property.

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -121,7 +121,7 @@ public:
             std::forward<typename property_by_key<keys>::type>(values)...
         )};
 
-        initialize_if_unused<decltype(factory), property_by_key<keys>...>(
+        initialize_if_unused<decltype(factory), keys...>(
             retval,
             std::forward<typename property_by_key<keys>::type>(values)...
         );
@@ -219,24 +219,24 @@ private:
      */
     template <
         typename Constructor, ///< constructor to consider
-        typename Attribute0, ///< first of the attributes
-        typename ...Attributes ///< rest of the attributes
+        key_type key0, ///< first of the attributes' keys
+        key_type ...keys ///< rest of the attributes' keys
     >
     void
     initialize_if_unused(
         object_type& obj, ///< object on which to set the attributes' values
-        typename Attribute0::type&& value0, ///< first of the values
-        typename Attributes::type&&... values ///< rest of the values
+        typename property_by_key<key0>::type&& value0, ///< first of the values
+        typename property_by_key<keys>::type&&... values ///< rest of the values
     ) const {
-        initialize_single_if_unused<Constructor, Attribute0>(
+        initialize_single_if_unused<Constructor, key0>(
             obj,
-            std::forward<typename Attribute0::type>(value0)
+            std::forward<typename property_by_key<key0>::type>(value0)
         );
 
         // recurse
-        initialize_if_unused<Constructor, Attributes...>(
+        initialize_if_unused<Constructor, keys...>(
             obj,
-            std::forward<typename Attributes::type>(values)...
+            std::forward<typename property_by_key<keys>::type>(values)...
         );
     }
 
@@ -255,31 +255,32 @@ private:
      */
     template <
         typename Constructor, ///< constructor to consider
-        typename Attribute ///< attribute to set
+        key_type key ///< attribute to set
     >
     typename std::enable_if<
-        !Constructor::template uses<Attribute::key>::value
+        !Constructor::template uses<key>::value
     >::type
     initialize_single_if_unused(
         object_type& obj, ///< object on which to set the attribute's value
-        typename Attribute::type&& value ///< value to set
+        typename property_by_key<key>::type&& value ///< value to set
     ) const {
         // TODO: static assertion for unsettable attributes
-        set<Attribute::key>(obj, std::forward<typename Attribute::type>(value));
+        set<key>(obj, std::forward<typename property_by_key<key>::type>(value));
     }
 
     // overload for attributes which are used by the constructor specified
     template <
         typename Constructor,
-        typename Attribute
+        key_type key
     >
     typename std::enable_if<
-        Constructor::template uses<Attribute::key>::value
+        Constructor::template uses<key>::value
     >::type
     initialize_single_if_unused(
         object_type& obj,
-        typename Attribute::type&& value
+        typename property_by_key<key>::type&& value
     ) const {}
+
 
     template <
         typename Type,

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -180,7 +180,7 @@ public:
         optional<Type> retval;
 
         visit_attributes<Type>([&retval, &obj, key] (auto accessor) {
-            if (cmoh::accessors::property<decltype(accessor)>::type::key != key)
+            if (cmoh::accessors::key(accessor) != key)
                 return;
             retval = accessor.get(obj);
         });
@@ -203,7 +203,7 @@ public:
         bool retval = false;
 
         visit_attributes<Type>([&retval, &obj, key, &value] (auto accessor) {
-            if (cmoh::accessors::property<decltype(accessor)>::type::key != key)
+            if (cmoh::accessors::key(accessor) != key)
                 return;
             accessor.set(obj, std::forward<Type>(value));
             retval = true;

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -70,7 +70,7 @@ public:
      * Common key type of all accessors
      */
     typedef typename util::common_type<
-        typename cmoh::accessors::property<Accessors>::type::key_type...
+        typename cmoh::accessors::key_type<Accessors>::type...
     >::type key_type;
 
     /**

--- a/include/cmoh/accessors/factory/abstract_factory.hpp
+++ b/include/cmoh/accessors/factory/abstract_factory.hpp
@@ -90,7 +90,7 @@ struct abstract_factory {
     >
     using property_by_key = util::common_type<
         typename std::conditional<
-            Attributes::key == static_cast<decltype(Attributes::key)>(key),
+            Attributes::key() == static_cast<decltype(Attributes::key())>(key),
             Attributes,
             void
         >::type...

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -144,6 +144,35 @@ public:
 
 
 /**
+ * Query an accessor's key type
+ */
+template <
+    typename Accessor
+>
+struct key_type {
+private:
+    template <
+        typename T,
+        typename = void
+    >
+    struct helper {
+        typedef typename cmoh::accessors::property<Accessor>::type::key_type
+            type;
+    };
+
+    template <
+        typename T
+    >
+    struct helper<T, util::void_t<typename T::key_type>> {
+        typedef typename Accessor::key_type type;
+    };
+
+public:
+    typedef typename helper<Accessor>::type type;
+};
+
+
+/**
  * Check whether an accessor accesses one of several properties
  *
  * Provides the member `value`, which is true if the accessor provided accesses

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -122,12 +122,12 @@ private:
         accessor_type acc_type
     >
     struct helper {
-        typedef void type;
+        typedef T type;
     };
 
     template <typename T>
     struct helper<T, factory_implementation> {
-        typedef T type;
+        typedef void type;
     };
 
     template <typename T>

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -173,6 +173,21 @@ public:
 
 
 /**
+ * Query the key associated with an accessor's attribute
+ */
+template <
+    typename Accessor
+>
+constexpr
+typename std::remove_reference<typename key_type<Accessor>::type>::type
+key(
+    Accessor const& accessor
+) {
+    return cmoh::accessors::property<Accessor>::type::key();
+}
+
+
+/**
  * Check whether an accessor accesses one of several properties
  *
  * Provides the member `value`, which is true if the accessor provided accesses
@@ -194,8 +209,8 @@ private:
     template <
         typename T
     >
-    struct helper<T, util::void_t<decltype(T::key)>> :
-        util::disjunction<std::integral_constant<bool, T::key == keys>...> {};
+    struct helper<T, util::void_t<decltype(T::key())>> :
+        util::disjunction<std::integral_constant<bool, T::key() == keys>...> {};
 
 public:
     enum : bool {value = helper<typename property<Accessor>::type>::value};

--- a/include/cmoh/attribute.hpp
+++ b/include/cmoh/attribute.hpp
@@ -71,8 +71,12 @@ struct attribute {
     enum : bool {is_const = std::is_const<Type>::value};
 
 
-    static constexpr const typename std::remove_reference<key_type>::type key =
-        Key;
+    static
+    constexpr
+    typename std::remove_reference<key_type>::type
+    key() {
+        return Key;
+    }
 
 
     /**


### PR DESCRIPTION
This PR resolves some linking issues encountered during work on #57. Exporting the key via a method no longer causes it to be dropped during the compilation process.

It also brings minor fixes, as well as a planned rewrite of a private accessor bundle facility, which was necessary because of the changes regarding keys.

Blocks #63.
