### PR TITLE
Enable usage of alternative key types

### DIFF
--- a/examples/string_key_example.cpp
+++ b/examples/string_key_example.cpp
@@ -32,6 +32,7 @@
 
 // CMOH includes
 #include <cmoh/string_view.hpp>
+#include <cmoh/string_utils.hpp>
 
 #include <cmoh/accessor_bundle.hpp>
 #include <cmoh/attribute.hpp>
@@ -63,7 +64,6 @@ operator << (std::ostream& stream, std::chrono::hours const& value) {
     return stream << value.count() << " hours";
 }
 
-
 int main(int argc, char* argv[]) {
     // We create an accessor bundle.
     auto accessors = bundle(
@@ -80,10 +80,17 @@ int main(int argc, char* argv[]) {
     );
 
     // Having strings, we can pretty-print the object using a visitor.
-    accessors.visit_properties([&] (auto accessor) {
+    auto printer = [&] (auto accessor) {
         std::cout << cmoh::accessors::key(accessor) << ": " << accessor.get(p);
         std::cout << std::endl;
-    });
+    };
+    accessors.visit_properties(printer);
+
+    std::cout << std::endl;
+
+    // we can also address properties using strings at run time
+    assert(accessors.set<std::string>(p, std::string("name"), "Hans Wurst"));
+    accessors.visit_properties(printer);
 
     return 0;
 }

--- a/include/cmoh/accessor_bundle.hpp
+++ b/include/cmoh/accessor_bundle.hpp
@@ -170,16 +170,17 @@ public:
      * \returns the value of the attribute
      */
     template <
-        typename Type ///< type of the attribute to get
+        typename Type, ///< type of the attribute to get
+        typename KeyType = key_type ///< key type to use
     >
     optional<Type>
     get(
         object_type const& obj, ///< object from which to get the value
-        key_type key ///< key of the attribute to get
+        KeyType&& key ///< key of the attribute to get
     ) const {
         optional<Type> retval;
 
-        visit_attributes<Type>([&retval, &obj, key] (auto accessor) {
+        visit_attributes<Type>([&] (auto accessor) {
             if (cmoh::accessors::key(accessor) != key)
                 return;
             retval = accessor.get(obj);
@@ -192,17 +193,18 @@ public:
      * Set the value of a specific attribute on an object
      */
     template <
-        typename Type ///< type of the attribute to get
+        typename Type, ///< type of the attribute to get
+        typename KeyType = key_type ///< key type to use
     >
     bool
     set(
         object_type& obj, ///< object on which to set the attribute
-        key_type key, ///< key of the attribute to get
+        KeyType&& key, ///< key of the attribute to get
         Type&& value ///< value to set
     ) const {
         bool retval = false;
 
-        visit_attributes<Type>([&retval, &obj, key, &value] (auto accessor) {
+        visit_attributes<Type>([&] (auto accessor) {
             if (cmoh::accessors::key(accessor) != key)
                 return;
             accessor.set(obj, std::forward<Type>(value));

--- a/include/cmoh/string_utils.hpp
+++ b/include/cmoh/string_utils.hpp
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Julian Ganz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef CMOH_STRING_UTILS_HPP__
+#define CMOH_STRING_UTILS_HPP__
+
+
+// std includes
+#include <string>
+
+// local includes
+#include <cmoh/string_view.hpp>
+
+
+
+
+// work-arounds for comparing strings to string views
+template <
+    typename Traits
+>
+bool
+operator == (
+    std::string const& string,
+    cmoh::basic_string_view<std::string::value_type, Traits> view
+) {
+    auto v = cmoh::std_traits_using(view);
+    return string.compare(0, string.length(), v.data(), v.size()) == 0;
+}
+
+template <
+    typename Traits
+>
+bool
+operator == (
+    cmoh::basic_string_view<std::string::value_type, Traits> view,
+    std::string const& string
+) {
+    return string == view;
+}
+
+
+template <
+    typename Traits
+>
+bool
+operator != (
+    std::string const& string,
+    cmoh::basic_string_view<std::string::value_type, Traits> view
+) {
+    return !(string == view);
+}
+
+template <
+    typename Traits
+>
+bool
+operator != (
+    cmoh::basic_string_view<std::string::value_type, Traits> view,
+    std::string const& string
+) {
+    return !(string == view);
+}
+
+
+
+
+#endif

--- a/include/cmoh/string_view.hpp
+++ b/include/cmoh/string_view.hpp
@@ -399,7 +399,138 @@ cmoh_traits_using(
 }
 
 
-// workaround to interface our custom char traits with the outside world
+// workarounds to interface our custom char traits with the outside world
+template<
+    class CharT
+>
+constexpr bool operator == (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs == cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator == (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) == rhs;
+}
+
+
+template<
+    class CharT,
+    class Traits
+>
+constexpr bool operator != (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs != cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator != (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) != rhs;
+}
+
+
+template<
+    class CharT,
+    class Traits
+>
+constexpr bool operator < (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs < cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator < (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) < rhs;
+}
+
+
+template<
+    class CharT,
+    class Traits
+>
+constexpr bool operator <= (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs <= cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator <= (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) <= rhs;
+}
+
+
+template<
+    class CharT,
+    class Traits
+>
+constexpr bool operator > (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs > cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator > (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) > rhs;
+}
+
+
+template<
+    class CharT,
+    class Traits
+>
+constexpr bool operator >= (
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> rhs
+) noexcept {
+    return lhs >= cmoh_traits_using(rhs);
+}
+
+template<
+    class CharT
+>
+constexpr bool operator >= (
+    cmoh::basic_string_view<CharT,  std::char_traits<CharT>> lhs,
+    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> rhs
+) noexcept {
+    return cmoh_traits_using(lhs) >= rhs;
+}
+
+
 template <
     class CharT
 >

--- a/include/cmoh/string_view.hpp
+++ b/include/cmoh/string_view.hpp
@@ -405,19 +405,10 @@ template <
 >
 std::basic_ostream<CharT, std::char_traits<CharT>>&
 operator << (
-    std::basic_ostream<CharT, std::char_traits<CharT>>& stream,
-    cmoh::basic_string_view<CharT, cmoh::char_traits<CharT>> view
+    std::basic_ostream<CharT>& stream,
+    cmoh::basic_string_view<CharT> view
 ) {
-    auto len = view.size();
-    auto pos = view.data();
-
-    while (len > 0) {
-        stream.put(*pos);
-        ++pos;
-        --len;
-    }
-
-    return stream;
+    return stream << std_traits_using(view);
 }
 
 

--- a/include/cmoh/string_view.hpp
+++ b/include/cmoh/string_view.hpp
@@ -361,6 +361,41 @@ typedef basic_string_view<char16_t> u16string_view;
 typedef basic_string_view<char32_t> u32string_view;
 
 
+/**
+ * Create a string view with the standard char traits
+ */
+template <
+    typename CharT,
+    typename Traits
+>
+constexpr
+basic_string_view<CharT, std::char_traits<CharT>>
+std_traits_using(
+    basic_string_view<CharT, Traits> const& view
+) {
+    return basic_string_view<CharT, std::char_traits<CharT>>(
+        view.data(),
+        view.size()
+    );
+}
+
+
+/**
+ * Create a string view with the cmoh char traits
+ */
+template <
+    typename CharT,
+    typename Traits
+>
+constexpr
+basic_string_view<CharT>
+cmoh_traits_using(
+    basic_string_view<CharT, Traits> const& view
+) {
+    return basic_string_view<CharT>(view.data(), view.size());
+}
+
+
 }
 
 

--- a/include/cmoh/string_view.hpp
+++ b/include/cmoh/string_view.hpp
@@ -353,10 +353,14 @@ operator << (
 
 
 namespace cmoh {
-    typedef basic_string_view<char> string_view;
-    typedef basic_string_view<wchar_t> wstring_view;
-    typedef basic_string_view<char16_t> u16string_view;
-    typedef basic_string_view<char32_t> u32string_view;
+
+
+typedef basic_string_view<char> string_view;
+typedef basic_string_view<wchar_t> wstring_view;
+typedef basic_string_view<char16_t> u16string_view;
+typedef basic_string_view<char32_t> u32string_view;
+
+
 }
 
 


### PR DESCRIPTION
WIP. Resolves #65.

This PR modifies the dynamic variants of the getter and setter in the accessor bundle. It will also introduce a few more conveniences for string key usage and expand the string key example to show off the new capabilities.
