### PR TITLE
Redefine accessor conventions

### DIFF
--- a/include/cmoh/accessors/attribute/by_invocable.hpp
+++ b/include/cmoh/accessors/attribute/by_invocable.hpp
@@ -55,7 +55,7 @@ template <
     typename Getter ///< type of the getter
 >
 struct by_invocable_const {
-    typedef Attribute attribute; ///< type of attribute being accessed
+    typedef Attribute property; ///< type of property being accessed
     typedef ObjType object_type; ///< object being accessed
 
     typedef Getter getter; // type of the getter used
@@ -69,7 +69,7 @@ struct by_invocable_const {
     static_assert(
         std::is_convertible<
             decltype(util::invoke(std::declval<getter>(), std::declval<object_type>())),
-            typename attribute::type
+            typename property::type
         >::value,
         "Value returned by getter is not convertible to attribute type"
     );
@@ -85,7 +85,7 @@ struct by_invocable_const {
      *
      * \returns the attribute's value
      */
-    typename attribute::type
+    typename property::type
     get(
         object_type const& obj ///< object from which to get the value
     ) const {
@@ -113,7 +113,7 @@ template <
     typename Setter ///< type of the setter
 >
 struct by_invocable : by_invocable_const<Attribute, ObjType, Getter> {
-    typedef Attribute attribute; ///< type of attribute being accessed
+    typedef Attribute property; ///< type of property being accessed
     typedef ObjType object_type; ///< object being accessed
 
     typedef Getter getter; // type of the getter used
@@ -124,7 +124,7 @@ struct by_invocable : by_invocable_const<Attribute, ObjType, Getter> {
         util::is_invocable<
             setter,
             object_type,
-            typename attribute::type
+            typename property::type
         >::value,
         "Getter not invokable with object"
     );
@@ -143,9 +143,9 @@ struct by_invocable : by_invocable_const<Attribute, ObjType, Getter> {
     void
     set(
         object_type& obj, ///< object on which to set the attribute
-        typename attribute::type&& value ///< value to set
+        typename property::type&& value ///< value to set
     ) const {
-        util::invoke(_setter, obj, std::forward<typename attribute::type>(value));
+        util::invoke(_setter, obj, std::forward<typename property::type>(value));
     }
 
 private:

--- a/include/cmoh/accessors/attribute/by_offset.hpp
+++ b/include/cmoh/accessors/attribute/by_offset.hpp
@@ -52,13 +52,13 @@ template <
     typename Value ///< type of the attribute in the class
 >
 struct by_offset {
-    typedef Attribute attribute; ///< type of attribute being accessed
+    typedef Attribute property; ///< type of property being accessed
     typedef ObjType object_type; ///< object being accessed
     typedef Value value_type; ///< actual type within the object
 
 
     static_assert(
-        std::is_convertible<object_type, typename attribute::type>::value,
+        std::is_convertible<object_type, typename property::type>::value,
         "Attribute type and real type not compatible."
     );
 
@@ -72,7 +72,7 @@ struct by_offset {
      *
      * \returns the attribute's value
      */
-    typename attribute::type
+    typename property::type
     get(
         object_type const& obj ///< object from which to get the value
     ) const {
@@ -87,7 +87,7 @@ struct by_offset {
     void
     set(
         object_type& obj, ///< object on which to set the attribute
-        typename attribute::type&& value ///< value to set
+        typename property::type&& value ///< value to set
     ) const {
         *reinterpret_cast<value_type*>(
             reinterpret_cast<char*>(&obj) + _offset

--- a/include/cmoh/accessors/factory/abstract_factory.hpp
+++ b/include/cmoh/accessors/factory/abstract_factory.hpp
@@ -52,7 +52,7 @@ struct abstract_factory {
      * The common key type of all attributes used
      */
     typedef typename util::common_type<
-        typename property<Attributes>::type::key_type...
+        typename Attributes::key_type...
     >::type key_type;
 
     /**

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -127,39 +127,26 @@ using accessor_type_of = std::integral_constant<
 
 
 /**
- * Query an accessor's underlying type
+ * Query the property associated with an accessor
  *
- * Returns an accessor's underlying property (e.g. the type containing the
- * members `key_type` and `key`) or void via the member `type`.
+ * Returns the property associated with the accessor type passed. If the type is
+ * not an accessor exposing a `property` member type, it may be a property
+ * itself. In this case, the type is returned.
+ *
+ * If the type is neither an accessor nor a property, `void` is returned.
  */
 template <
-    typename Accessor
+    typename Accessible,
+    typename = void
 >
-struct property {
-private:
-    template <
-        typename T,
-        accessor_type acc_type
-    >
-    struct helper {
-        typedef T type;
-    };
+struct property :
+    std::conditional<is_property<Accessible>::value, Accessible, void> {};
 
-    template <typename T>
-    struct helper<T, factory_implementation> {
-        typedef void type;
-    };
-
-    template <typename T>
-    struct helper<T, attribute_accessor> {
-        typedef typename T::property type;
-    };
-
-public:
-    typedef typename helper<
-        Accessor,
-        accessor_type_of<Accessor>::value
-    >::type type;
+template <
+    typename Accessible
+>
+struct property<Accessible, util::void_t<typename Accessible::property>> {
+    typedef typename Accessible::property type;
 };
 
 

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -100,33 +100,6 @@ struct is_attribute_accessor<
 
 
 /**
- * Enumeration type for detecting different types of accessors
- */
-enum accessor_type {
-    none, ///< not an accessor
-    factory_implementation, ///< a factory
-    attribute_accessor ///< an attribute accessor
-};
-
-
-/**
- * Meta function for querying the accessor type of a type
- *
- * Returns the `accessor_type` associated with the `Accessor` supplied via the
- * `value` member.
- */
-template <
-    typename Accessor
->
-using accessor_type_of = std::integral_constant<
-    accessor_type,
-    is_factory<Accessor>::value ? factory_implementation :
-    is_attribute_accessor<Accessor>::value ? attribute_accessor :
-    none
->;
-
-
-/**
  * Query the property associated with an accessor
  *
  * Returns the property associated with the accessor type passed. If the type is

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -38,6 +38,23 @@ namespace accessors {
 
 
 /**
+ * Check whether a type is an addressable property
+ *
+ * A property has a key which can be retrieved via the `key()` method.
+ */
+template <
+    typename Property,
+    typename = void
+>
+struct is_property : std::false_type {};
+
+template <
+    typename Property
+>
+struct is_property<Property, util::void_t<decltype(Property::key())>> : std::true_type {};
+
+
+/**
  * Check whether a supposed accessor is a factory
  *
  * Detection is performed by detecting the `is_initializable_from` member.

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -135,7 +135,7 @@ private:
 
     template <typename T>
     struct helper<T, attribute_accessor> {
-        typedef typename T::attribute type;
+        typedef typename T::property type;
     };
 
 public:

--- a/include/cmoh/accessors/utils.hpp
+++ b/include/cmoh/accessors/utils.hpp
@@ -61,7 +61,8 @@ struct is_factory<
 /**
  * Check whether a supposed accessor is an attribute accessor
  *
- * Detection is performed by detecting the `attribute` member.
+ * An attribute accessor has a method `get()` which accepts an object of the
+ * cotnained object_type.
  */
 template <
     typename Accessor, ///< accessor to check
@@ -75,7 +76,9 @@ template <
 >
 struct is_attribute_accessor<
     Accessor,
-    util::void_t<typename Accessor::attribute>
+    util::void_t<decltype(std::declval<Accessor>().get(
+            std::declval<typename Accessor::object_type>()
+    ))>
 > : std::true_type {};
 
 


### PR DESCRIPTION
We redefine some of the accessor conventions, resulting in less code.
Resolves #74.